### PR TITLE
Add liquibase:clearCheckSums command.

### DIFF
--- a/src/main/java/io/bootique/liquibase/LiquibaseModule.java
+++ b/src/main/java/io/bootique/liquibase/LiquibaseModule.java
@@ -9,8 +9,11 @@ import io.bootique.ConfigModule;
 import io.bootique.config.ConfigurationFactory;
 import io.bootique.jdbc.DataSourceFactory;
 import io.bootique.liquibase.annotation.ChangeLogs;
+import io.bootique.liquibase.command.ChangelogSyncCommand;
+import io.bootique.liquibase.command.ChangelogSyncSqlCommand;
 import io.bootique.liquibase.command.ClearCheckSumsCommand;
 import io.bootique.liquibase.command.UpdateCommand;
+import io.bootique.liquibase.command.ValidateCommand;
 import io.bootique.resource.ResourceFactory;
 
 import java.util.Set;
@@ -32,7 +35,13 @@ public class LiquibaseModule extends ConfigModule {
 
     @Override
     public void configure(Binder binder) {
-        asList(UpdateCommand.class, ClearCheckSumsCommand.class).forEach(command ->
+        asList(
+                UpdateCommand.class,
+                ValidateCommand.class,
+                ChangelogSyncCommand.class,
+                ClearCheckSumsCommand.class,
+                ChangelogSyncSqlCommand.class
+        ).forEach(command ->
                 BQCoreModule.contributeCommands(binder).addBinding().to(command).in(Singleton.class));
         contributeChangeLogs(binder);
     }

--- a/src/main/java/io/bootique/liquibase/LiquibaseModule.java
+++ b/src/main/java/io/bootique/liquibase/LiquibaseModule.java
@@ -9,10 +9,13 @@ import io.bootique.ConfigModule;
 import io.bootique.config.ConfigurationFactory;
 import io.bootique.jdbc.DataSourceFactory;
 import io.bootique.liquibase.annotation.ChangeLogs;
+import io.bootique.liquibase.command.ClearCheckSumsCommand;
 import io.bootique.liquibase.command.UpdateCommand;
 import io.bootique.resource.ResourceFactory;
 
 import java.util.Set;
+
+import static java.util.Arrays.asList;
 
 public class LiquibaseModule extends ConfigModule {
 
@@ -29,7 +32,8 @@ public class LiquibaseModule extends ConfigModule {
 
     @Override
     public void configure(Binder binder) {
-        BQCoreModule.contributeCommands(binder).addBinding().to(UpdateCommand.class).in(Singleton.class);
+        asList(UpdateCommand.class, ClearCheckSumsCommand.class).forEach(command ->
+                BQCoreModule.contributeCommands(binder).addBinding().to(command).in(Singleton.class));
         contributeChangeLogs(binder);
     }
 

--- a/src/main/java/io/bootique/liquibase/command/ChangelogSyncCommand.java
+++ b/src/main/java/io/bootique/liquibase/command/ChangelogSyncCommand.java
@@ -1,0 +1,42 @@
+package io.bootique.liquibase.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.bootique.cli.Cli;
+import io.bootique.command.CommandOutcome;
+import io.bootique.command.CommandWithMetadata;
+import io.bootique.liquibase.LiquibaseRunner;
+import io.bootique.meta.application.CommandMetadata;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ChangelogSyncCommand extends CommandWithMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangelogSyncCommand.class);
+
+    private Provider<LiquibaseRunner> runnerProvider;
+
+    @Inject
+    public ChangelogSyncCommand(Provider<LiquibaseRunner> runnerProvider) {
+        super(CommandMetadata.builder(ChangelogSyncCommand.class)
+                .description("Mark all changes as executed in the database.").build());
+        this.runnerProvider = runnerProvider;
+    }
+
+    @Override
+    public CommandOutcome run(Cli cli) {
+
+        LOGGER.info("Will run 'liquibase changelogSync'...");
+
+        return runnerProvider.get().runWithLiquibase(lb -> {
+            try {
+                lb.changeLogSync(new Contexts(), new LabelExpression());
+                return CommandOutcome.succeeded();
+            } catch (Exception e) {
+                return CommandOutcome.failed(1, e);
+            }
+        });
+    }
+}

--- a/src/main/java/io/bootique/liquibase/command/ChangelogSyncSqlCommand.java
+++ b/src/main/java/io/bootique/liquibase/command/ChangelogSyncSqlCommand.java
@@ -1,0 +1,46 @@
+package io.bootique.liquibase.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.bootique.cli.Cli;
+import io.bootique.command.CommandOutcome;
+import io.bootique.command.CommandWithMetadata;
+import io.bootique.liquibase.LiquibaseRunner;
+import io.bootique.meta.application.CommandMetadata;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+
+public class ChangelogSyncSqlCommand extends CommandWithMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangelogSyncSqlCommand.class);
+
+    private Provider<LiquibaseRunner> runnerProvider;
+
+    @Inject
+    public ChangelogSyncSqlCommand(Provider<LiquibaseRunner> runnerProvider) {
+        super(CommandMetadata.builder(ChangelogSyncSqlCommand.class)
+                .description("Writes SQL to mark all changes as executed in the database to STDOUT.").build());
+        this.runnerProvider = runnerProvider;
+    }
+
+    @Override
+    public CommandOutcome run(Cli cli) {
+
+        LOGGER.info("Will run 'liquibase changelogSyncSQL'...");
+
+        return runnerProvider.get().runWithLiquibase(lb -> {
+            try {
+                lb.changeLogSync(new Contexts(), new LabelExpression(),
+                        new BufferedWriter(new OutputStreamWriter(System.out)));
+                return CommandOutcome.succeeded();
+            } catch (Exception e) {
+                return CommandOutcome.failed(1, e);
+            }
+        });
+    }
+}

--- a/src/main/java/io/bootique/liquibase/command/ClearCheckSumsCommand.java
+++ b/src/main/java/io/bootique/liquibase/command/ClearCheckSumsCommand.java
@@ -1,0 +1,42 @@
+package io.bootique.liquibase.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.bootique.meta.application.CommandMetadata;
+import io.bootique.cli.Cli;
+import io.bootique.command.CommandOutcome;
+import io.bootique.command.CommandWithMetadata;
+import io.bootique.liquibase.LiquibaseRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClearCheckSumsCommand extends CommandWithMetadata {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClearCheckSumsCommand.class);
+
+    private Provider<LiquibaseRunner> runnerProvider;
+
+    @Inject
+    public ClearCheckSumsCommand(Provider<LiquibaseRunner> runnerProvider) {
+        super(CommandMetadata
+                .builder(ClearCheckSumsCommand.class)
+                .description("Clears all checksums in the current changelog, so they will be recalculated next update.")
+                .build());
+        this.runnerProvider = runnerProvider;
+    }
+
+    @Override
+    public CommandOutcome run(Cli cli) {
+
+        LOGGER.info("Will run 'liquibase clearCheckSums'...");
+
+        return runnerProvider.get().runWithLiquibase(lb -> {
+            try {
+                lb.clearCheckSums();
+                return CommandOutcome.succeeded();
+            } catch (Exception e) {
+                return CommandOutcome.failed(1, e);
+            }
+        });
+    }
+}
+

--- a/src/main/java/io/bootique/liquibase/command/ValidateCommand.java
+++ b/src/main/java/io/bootique/liquibase/command/ValidateCommand.java
@@ -1,0 +1,40 @@
+package io.bootique.liquibase.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.bootique.cli.Cli;
+import io.bootique.command.CommandOutcome;
+import io.bootique.command.CommandWithMetadata;
+import io.bootique.liquibase.LiquibaseRunner;
+import io.bootique.meta.application.CommandMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ValidateCommand extends CommandWithMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidateCommand.class);
+
+    private Provider<LiquibaseRunner> runnerProvider;
+
+    @Inject
+    public ValidateCommand(Provider<LiquibaseRunner> runnerProvider) {
+        super(CommandMetadata.builder(ValidateCommand.class)
+                .description("Checks the changelog for errors.").build());
+        this.runnerProvider = runnerProvider;
+    }
+
+    @Override
+    public CommandOutcome run(Cli cli) {
+
+        LOGGER.info("Will run 'liquibase validate'...");
+
+        return runnerProvider.get().runWithLiquibase(lb -> {
+            try {
+                lb.validate();
+                return CommandOutcome.succeeded();
+            } catch (Exception e) {
+                return CommandOutcome.failed(1, e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Clears all checksums in the current changelog, so they will be recalculated next update.