### PR TITLE
Add "drop-all" command 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,7 @@
 * #14 ChangelogSyncSqlCommand got lost
 * #16 Namespace the commands 
 * #18 Add Liquibase context to control which changeSets will be executed in migration run 
-* #15 Add "delete-all" command
+* #15 Add "drop-all" command
 
 ## 0.12
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 * #14 ChangelogSyncSqlCommand got lost
 * #16 Namespace the commands 
 * #18 Add Liquibase context to control which changeSets will be executed in migration run 
+* #15 Add "delete-all" command
 
 ## 0.12
 

--- a/src/main/java/io/bootique/liquibase/LiquibaseModule.java
+++ b/src/main/java/io/bootique/liquibase/LiquibaseModule.java
@@ -12,6 +12,7 @@ import io.bootique.liquibase.annotation.ChangeLogs;
 import io.bootique.liquibase.command.ChangelogSyncCommand;
 import io.bootique.liquibase.command.ChangelogSyncSqlCommand;
 import io.bootique.liquibase.command.ClearCheckSumsCommand;
+import io.bootique.liquibase.command.DropAllCommand;
 import io.bootique.liquibase.command.UpdateCommand;
 import io.bootique.liquibase.command.ValidateCommand;
 import io.bootique.meta.application.OptionMetadata;
@@ -62,6 +63,7 @@ public class LiquibaseModule extends ConfigModule {
                 .addCommand(ChangelogSyncSqlCommand.class)
                 .addCommand(ClearCheckSumsCommand.class)
                 .addCommand(ChangelogSyncCommand.class)
+                .addCommand(DropAllCommand.class)
                 .addOption(createContextOption());
     }
 

--- a/src/main/java/io/bootique/liquibase/command/DropAllCommand.java
+++ b/src/main/java/io/bootique/liquibase/command/DropAllCommand.java
@@ -1,0 +1,66 @@
+package io.bootique.liquibase.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.bootique.cli.Cli;
+import io.bootique.command.CommandOutcome;
+import io.bootique.command.CommandWithMetadata;
+import io.bootique.liquibase.LiquibaseRunner;
+import io.bootique.meta.application.CommandMetadata;
+import io.bootique.meta.application.OptionMetadata;
+import liquibase.CatalogAndSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @since 0.13
+ */
+public class DropAllCommand extends CommandWithMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DropAllCommand.class);
+
+    private Provider<LiquibaseRunner> runnerProvider;
+
+    @Inject
+    public DropAllCommand(Provider<LiquibaseRunner> runnerProvider) {
+        super(CommandMetadata
+                .builder(DropAllCommand.class)
+                .name("lb-drop-all")
+                .description("Drops all database objects in the configured schema(s). " +
+                        "Note that functions, procedures and packages are not dropped.")
+                .addOptions(
+                        Stream.of(
+                                OptionMetadata
+                                        .builder("schema")
+                                        .valueRequired("schema_name")
+                                        .description("Schema against which 'liquibase dropAll' will be executed.")
+                                        .build(),
+                                OptionMetadata
+                                        .builder("catalog")
+                                        .valueRequired("catalog_name")
+                                        .description("Catalog against which 'liquibase dropAll' will be executed.")
+                                        .build())
+                                .collect(Collectors.toList()))
+                .build());
+
+        this.runnerProvider = runnerProvider;
+    }
+
+
+    @Override
+    public CommandOutcome run(Cli cli) {
+        LOGGER.info("Will run 'liquibase dropAll'...");
+
+        return runnerProvider.get().runWithLiquibase(lb -> {
+            try {
+                lb.dropAll(new CatalogAndSchema(cli.optionString("catalog"), cli.optionString("schema")));
+                return CommandOutcome.succeeded();
+            } catch (Exception e) {
+                return CommandOutcome.failed(1, e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Ref: bootique/bootique-liquibase#15

New command "--lb-drop-all" with CLI options "--schema" and "--catalog" has been introduced.
It has been named "--lb-drop-all" because of original [LQ name](http://www.liquibase.org/documentation/maven/maven_dropall.html).